### PR TITLE
patch to fix undefined method `configure' for Spec::Runner:Module (NoMethodError) w/ latest rspec

### DIFF
--- a/lib/moqueue/matchers.rb
+++ b/lib/moqueue/matchers.rb
@@ -107,7 +107,13 @@ module Moqueue
 end
 
 if defined?(::Spec::Runner)
-  Spec::Runner.configure do |config|
-    config.include(::Moqueue::Matchers)
+  if Spec::Runner.respond_to?(:configure)
+    Spec::Runner.configure do |config|
+      config.include(::Moqueue::Matchers)
+    end
+  elsif defined?(::Rspec) && Rspec.respond_to?(:configure)
+    Rspec.configure do |config|
+      config.include(::Moqueue::Matchers)
+    end
   end
 end

--- a/lib/moqueue/mock_exchange.rb
+++ b/lib/moqueue/mock_exchange.rb
@@ -50,7 +50,7 @@ module Moqueue
       elsif direct
         attached_queues << [queue, DirectBindingKey.new(opts[:key])]
       else
-        attached_queues << queue
+        attached_queues << queue unless attached_queues.include?(queue)
       end
     end
     

--- a/spec/unit/mock_exchange_spec.rb
+++ b/spec/unit/mock_exchange_spec.rb
@@ -13,6 +13,8 @@ describe MockExchange do
     one_queue, another_queue = mock_queue("one"), mock_queue("two")
     exchange.attach_queue(one_queue)
     exchange.attach_queue(another_queue)
+    exchange.attached_queues.length.should == 2
+    lambda { exchange.attach_queue(one_queue) }.should_not change(exchange.attached_queues, :length)
     one_queue.subscribe do |msg|
       deferred_block_called && msg.should == "mmm, smoothies"
     end

--- a/spec/unit/mock_queue_spec.rb
+++ b/spec/unit/mock_queue_spec.rb
@@ -142,6 +142,17 @@ describe MockQueue do
     lambda {queue.bind(MockExchange.new)}.should_not raise_error
   end
   
+  
+  it "should bind to a fanout exchange only once" do
+    queue = MockQueue.new("fanouts are cool, too")
+    exchange = MockExchange.new('fanout')
+    queue.bind exchange
+    queue.bind exchange # should be silently ignored
+    exchange.publish "only get this once", {}
+    require 'pp'
+    pp exchange
+  end
+  
   it "should provide a null subscribe that does nothing but allows messages to be received" do
     queue = MockQueue.new("nilly").null_subscribe
     queue.publish("I'm feelin this")


### PR DESCRIPTION
Hi,

thanks for the super useful lib. Running w/   gem 'rspec-rails' , ">= 2.0.0.beta.22" I found myself getting

undefined method `configure' for Spec::Runner:Module (NoMethodError)
/Users/davidlee/.rvm/gems/ruby-1.9.2-head/gems/moqueue-0.1.4/lib/moqueue/matchers.rb:110:in`<top (required)>'

Please consider the patch supplied - it Works For Me (tm).

cheers,
David
