### PR TITLE
added basic support for MockQueue#unsubscribe

### DIFF
--- a/lib/moqueue/mock_queue.rb
+++ b/lib/moqueue/mock_queue.rb
@@ -50,7 +50,7 @@ module Moqueue
     end
     
     def unsubscribe
-      true
+      @subscribe_block = nil
     end
 
     def prefetch(size)

--- a/spec/unit/mock_queue_spec.rb
+++ b/spec/unit/mock_queue_spec.rb
@@ -94,6 +94,13 @@ describe MockQueue do
     @queue.should respond_to(:unsubscribe)
   end
 
+  it "should prevent double subscribe errors if unsubscribe is called inbetween" do
+    @queue.subscribe { |msg| "once" }
+    @queue.unsubscribe
+    @queue.subscribe { |msg| "second" }.should_not raise_error(DoubleSubscribeError)
+  end
+  
+
   it "should ignore #prefetch but at least raise an error" do
     lambda { @queue.prefetch(1337) }.should_not raise_error
   end


### PR DESCRIPTION
Hi Dan,

i came about an issue when using moqueue on different specs in another project where moqueue is used to mock the mq parts. It raised the DoubleSubscribeError even after calling unsubscrube on the mocked queue.

After browsing your source i found that unsubscribe is implemented rather small, so i tried to fix it. It works for me and i added an spec.

What do you think of my proposal?

Thanks 
Jörg
